### PR TITLE
Document more frequently used components

### DIFF
--- a/index.json
+++ b/index.json
@@ -474,7 +474,7 @@
                             "minecraft:behavior.vex_copy_owner_target",
                             "minecraft:behavior.vex_random_move",
                             "minecraft:behavior.wither_random_attack_pos_goal",
-                            "minecraft:behavior.wither_target_highest_damage",                    
+                            "minecraft:behavior.wither_target_highest_damage",
                             "minecraft:addrider",
                             "minecraft:admire_item",
                             "minecraft:ageable",
@@ -3036,6 +3036,7 @@
                             },
                             "effect_duration": {
                                 "type": "number",
+                                "default": 0.0,
                                 "description": "Duration of the applied potion effect."
                             }
                         }
@@ -3064,6 +3065,7 @@
                         "properties": {
                             "should_darken_sky": {
                                 "type": "boolean",
+                                "default": false,
                                 "description": "Whether the sky should darken in the presence of the boss."
                             },
                             "name": {
@@ -3072,6 +3074,7 @@
                             },
                             "hud_range": {
                                 "type": "number",
+                                "default": 55,
                                 "description": "The max distance from the boss at which the boss's health bar is present on the players screen."
                             }
                         }
@@ -3109,10 +3112,12 @@
                         "properties": {
                             "width": {
                                 "type": "number",
+                                "default": 1.0,
                                 "description": "Width and Depth of the collision box in blocks. A negative value will be assumed to be 0."
                             },
                             "height": {
                                 "type": "number",
+                                "default": 1.0,
                                 "description": "Height of the collision box in blocks. A negative value will be assumed to be 0."
                             }
                         }
@@ -3173,8 +3178,7 @@
                                 "$ref": "#/definitions/filters"
                             },
                             "remove_child_entities": {
-                                "type": "boolean",
-                                "description": "If true, all entities linked to this entity in a child relationship (eg. leashed) will also be despawned."
+                                "$ref": "#/definitions/library/components/values/remove_child_entities"
                             },
                             "despawn_from_distance": {
                                 "type": "object",
@@ -3191,22 +3195,27 @@
                             },
                             "despawn_from_chance": {
                                 "type": "boolean",
+                                "default": true,
                                 "description": "Determines if \"min_range_random_chance\" is used in the standard despawn rules"
                             },
                             "despawn_from_inactivity": {
                                 "type": "boolean",
+                                "default": true,
                                 "description": "Determines if the \"min_range_inactivity_timer\" is used in the standard despawn rules."
                             },
                             "despawn_from_simulation_edge": {
                                 "type": "boolean",
+                                "default": true,
                                 "description": "Determines if the mob is instantly despawned at the edge of simulation distance in the standard despawn rules."
                             },
                             "min_range_inactivity_timer": {
                                 "type": "number",
+                                "default": 30,
                                 "description": "The amount of time in seconds that the mob must be inactive."
                             },
                             "min_range_random_chance": {
                                 "type": "number",
+                                "default": 800,
                                 "description": "A random chance between 1 and the given value."
                             }
                         }
@@ -3233,22 +3242,27 @@
                         "properties": {
                             "sensor_range": {
                                 "type": "number",
+                                "default": 10,
                                 "description": "The maximum distance another entity can be from this and have the filters checked against it."
                             },
                             "relative_range": {
                                 "type": "boolean",
+                                "default": true,
                                 "description": "If true the sensor range is additive on top of the entity's size."
                             },
                             "require_all": {
                                 "type": "boolean",
+                                "default": false,
                                 "description": "If true requires all nearby entities to pass the filter conditions for the event to send."
                             },
                             "minimum_count": {
                                 "type": "number",
+                                "default": 1,
                                 "description": "The minimum number of entities that must pass the filter conditions for the event to send."
                             },
                             "maximum_count": {
                                 "type": "number",
+                                "default": -1,
                                 "description": "The maximum number of entities that must pass the filter conditions for the event to send."
                             },
                             "event_filters": {
@@ -3328,6 +3342,7 @@
                             "filters": { "$ref": "#/definitions/filters" },
                             "force_use": {
                                 "type": "boolean",
+                                "default": false,
                                 "description": "Determines if item can be used regardless of entity being at full health."
                             },
                             "items": {
@@ -3349,17 +3364,7 @@
                         }
                     },
                     "minecraft:health": {
-                        "type": "object",
-                        "properties": {
-                            "value": {
-                                "type": "integer",
-                                "description": "The  amount of health an entity has"
-                            },
-                            "max": {
-                                "type": "integer",
-                                "description": "The maximum amount of health an entity can have"
-                            }
-                        }
+                        "$ref": "#/definitions/library/components/values/current_and_max"
                     },
                     "minecraft:hide": {
                         "type": "object"
@@ -3509,15 +3514,7 @@
                         "type": "object"
                     },
                     "minecraft:knockback_resistance": {
-                        "type": "object",
-                        "properties": {
-                            "value": {
-                                "type": "number"
-                            },
-                            "max": {
-                                "type": "number"
-                            }
-                        }
+                        "$ref": "#/definitions/library/components/values/current_and_max"
                     },
                     "minecraft:lava_movement": {
                         "type": "object"
@@ -3660,10 +3657,12 @@
                         "properties": {
                             "is_pushable": {
                                 "type": "boolean",
+                                "default": true,
                                 "description": "Whether the entity can be pushed by other entities."
                             },
                             "is_pushable_by_piston": {
                                 "type": "boolean",
+                                "default": true,
                                 "description": "Whether the entity can be pushed by pistons safely."
                             }
                         }
@@ -3757,10 +3756,12 @@
                         "properties": {
                             "looping": {
                                 "type": "boolean",
+                                "default": true,
                                 "description": "If true, the timer will restart every time after it fires."
                             },
                             "time": {
                                 "type": "array",
+                                "default": [0.0, 0.0],
                                 "description": "Amount of time in seconds for the timer. Can be specified as a number or a pair of numbers (min and max). Incompatible with random_time_choices.",
                                 "items": {
                                     "type": "number"
@@ -3768,10 +3769,12 @@
                             },
                             "randomInterval": {
                                 "type": "boolean",
+                                "default": true,
                                 "description": "If true, the amount of time on the timer will be random between the min and max values specified in time."
                             },
                             "random_time_choices": {
                                 "type": "array",
+                                "default": [],
                                 "description": "This is a list of objects, representing one value in seconds that can be picked before firing the event and an optional weight. Incompatible with time.",
                                 "items": {
                                     "type": "object",
@@ -3849,7 +3852,7 @@
                         "type": "object"
                     },
                     "minecraft:water_movement": {
-                        "type": "object" 
+                        "type": "object"
                     }
                 },
                 "values": {
@@ -3911,12 +3914,24 @@
                     "scan_interval" : { "type": "integer", "default": 10.0 },
                     "persist_time" : { "type": "number", "default": 3.0 },
                     "attack_interval" : { "type": "integer", "default": 0 },
+                    "remove_child_entities" : { "type": "boolean", "description": "If true, all entities linked to this entity in a child relationship (eg. leashed) will also be despawned.", "default": false },
                     "trigger": {
                         "type": "object",
                         "properties": {
                             "filters": { "$ref": "#/definitions/filters" },
                             "event" : { "type": "string" },
                             "target": { "type": "string", "examples": [ "other", "player", "self", "target", "baby", "block" ] }
+                        }
+                    },
+                    "current_and_max": {
+                        "type": "object",
+                        "properties": {
+                            "value": {
+                                "type": "number"
+                            },
+                            "max": {
+                                "type": "number"
+                            }
                         }
                     },
                     "entity_types": {

--- a/index.json
+++ b/index.json
@@ -183,6 +183,12 @@
                         ] }
                 },
                 {
+                    "if": { "properties": { "test": { "anyOf": [ { "const": "has_damage" } ] } } },
+                    "then": { "allOf": [
+                        {"properties": { "value": { "type": "string", "$ref": "#/definitions/library/filters/domains/has_damage" } } }
+                    ] }
+                },
+                {
                     "if": { "properties": { "test": { "anyOf": [ { "const": "is_game_rule" } ] } } },
                     "then": { "properties": { "domain": { "type": "string", "$ref": "#/definitions/library/filters/domains/is_game_rule" } } }
                 }
@@ -1991,6 +1997,39 @@
                     "minecraft:zombie_villager_v2"
                 ]
             },
+            "effects": {
+                "enum": [
+                    "speed",
+                    "slowness",
+                    "haste",
+                    "mining_fatigue",
+                    "strength",
+                    "instant_health",
+                    "instant_damage",
+                    "jump_boost",
+                    "nausea",
+                    "regeneration",
+                    "resistance",
+                    "fire_resistance",
+                    "water_breathing",
+                    "invisibility",
+                    "blindness",
+                    "night_vision",
+                    "hunger",
+                    "weakness",
+                    "poison",
+                    "wither",
+                    "health_boost",
+                    "absorption",
+                    "saturation",
+                    "levitation",
+                    "fatal_poison",
+                    "conduit_power",
+                    "slow_falling",
+                    "bad_omen",
+                    "village_hero"
+                ]
+            },
             "components": {
                 "properties": {
                     "minecraft:behavior.hide": {
@@ -2984,7 +3023,22 @@
                         "type": "object"
                     },
                     "minecraft:attack": {
-                        "type": "object"
+                        "type": "object",
+                        "properties": {
+                            "damage": {
+                                "type": "number",
+                                "description": "How much damage is applied to attacked entity."
+                            },
+                            "effect_name": {
+                                "type": "string",
+                                "$ref": "#/definitions/library/effects",
+                                "description": "Potion effect applied to attacked entity."
+                            },
+                            "effect_duration": {
+                                "type": "number",
+                                "description": "Duration of the applied potion effect."
+                            }
+                        }
                     },
                     "minecraft:attack_cooldown": {
                         "type": "object"
@@ -3005,7 +3059,22 @@
                         "type": "object"
                     },
                     "minecraft:boss": {
-                        "type": "object"
+                        "type": "object",
+                        "description": "The current state of the boss for updating the boss HUD.",
+                        "properties": {
+                            "should_darken_sky": {
+                                "type": "boolean",
+                                "description": "Whether the sky should darken in the presence of the boss."
+                            },
+                            "name": {
+                                "type": "string",
+                                "description": "The name that will be displayed above the boss's health bar."
+                            },
+                            "hud_range": {
+                                "type": "number",
+                                "description": "The max distance from the boss at which the boss's health bar is present on the players screen."
+                            }
+                        }
                     },
                     "minecraft:break_blocks": {
                         "type": "object"
@@ -3035,7 +3104,18 @@
                         "type": "object"
                     },
                     "minecraft:collision_box": {
-                        "type": "object"
+                        "type": "object",
+                        "description": "Sets the width and height of the Entity's collision box.",
+                        "properties": {
+                            "width": {
+                                "type": "number",
+                                "description": "Width and Depth of the collision box in blocks. A negative value will be assumed to be 0."
+                            },
+                            "height": {
+                                "type": "number",
+                                "description": "Height of the collision box in blocks. A negative value will be assumed to be 0."
+                            }
+                        }
                     },
                     "minecraft:color": {
                         "type": "object",
@@ -3085,7 +3165,51 @@
                         }
                     },
                     "minecraft:despawn": {
-                        "type": "object"
+                        "type": "object",
+                        "description": "Despawns the Actor when the despawn rules or optional filters evaluate to true.",
+                        "properties": {
+                            "filters": {
+                                "description": "The list of conditions that must be satisfied before the Actor is despawned. If a filter is defined then standard despawn rules are ignored.",
+                                "$ref": "#/definitions/filters"
+                            },
+                            "remove_child_entities": {
+                                "type": "boolean",
+                                "description": "If true, all entities linked to this entity in a child relationship (eg. leashed) will also be despawned."
+                            },
+                            "despawn_from_distance": {
+                                "type": "object",
+                                "properties": {
+                                    "min_distance": {
+                                        "type": "number",
+                                        "description": "Maximum distance for standard despawn rules to instantly despawn the mob."
+                                    },
+                                    "max_distance": {
+                                        "type": "number",
+                                        "description": "Minimum distance for standard despawn rules to try to despawn the mob."
+                                    }
+                                }
+                            },
+                            "despawn_from_chance": {
+                                "type": "boolean",
+                                "description": "Determines if \"min_range_random_chance\" is used in the standard despawn rules"
+                            },
+                            "despawn_from_inactivity": {
+                                "type": "boolean",
+                                "description": "Determines if the \"min_range_inactivity_timer\" is used in the standard despawn rules."
+                            },
+                            "despawn_from_simulation_edge": {
+                                "type": "boolean",
+                                "description": "Determines if the mob is instantly despawned at the edge of simulation distance in the standard despawn rules."
+                            },
+                            "min_range_inactivity_timer": {
+                                "type": "number",
+                                "description": "The amount of time in seconds that the mob must be inactive."
+                            },
+                            "min_range_random_chance": {
+                                "type": "number",
+                                "description": "A random chance between 1 and the given value."
+                            }
+                        }
                     },
                     "minecraft:dweller": {
                         "type": "object"
@@ -3104,7 +3228,36 @@
                         }
                     },
                     "minecraft:entity_sensor": {
-                        "type": "object"
+                        "type": "object",
+                        "description": "A component that fires an event when a set of conditions are met by other entities within the defined range.",
+                        "properties": {
+                            "sensor_range": {
+                                "type": "number",
+                                "description": "The maximum distance another entity can be from this and have the filters checked against it."
+                            },
+                            "relative_range": {
+                                "type": "boolean",
+                                "description": "If true the sensor range is additive on top of the entity's size."
+                            },
+                            "require_all": {
+                                "type": "boolean",
+                                "description": "If true requires all nearby entities to pass the filter conditions for the event to send."
+                            },
+                            "minimum_count": {
+                                "type": "number",
+                                "description": "The minimum number of entities that must pass the filter conditions for the event to send."
+                            },
+                            "maximum_count": {
+                                "type": "number",
+                                "description": "The maximum number of entities that must pass the filter conditions for the event to send."
+                            },
+                            "event_filters": {
+                                "$ref": "#/definitions/filters"
+                            },
+                            "event": {
+                                "type": "string"
+                            }
+                        }
                     },
                     "minecraft:equipment": {
                         "type": "object"
@@ -3170,10 +3323,43 @@
                         "type": "object"
                     },
                     "minecraft:healable": {
-                        "type": "object"
+                        "type": "object",
+                        "properties": {
+                            "filters": { "$ref": "#/definitions/filters" },
+                            "force_use": {
+                                "type": "boolean",
+                                "description": "Determines if item can be used regardless of entity being at full health."
+                            },
+                            "items": {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "heal_amount": {
+                                            "type": "integer",
+                                            "description": "The amount of health this entity gains when fed this item."
+                                        },
+                                        "item": {
+                                            "type": "string",
+                                            "description": "Item identifier that can be used to heal this entity."
+                                        }
+                                    }
+                                }
+                            }
+                        }
                     },
                     "minecraft:health": {
-                        "type": "object"
+                        "type": "object",
+                        "properties": {
+                            "value": {
+                                "type": "integer",
+                                "description": "The  amount of health an entity has"
+                            },
+                            "max": {
+                                "type": "integer",
+                                "description": "The maximum amount of health an entity can have"
+                            }
+                        }
                     },
                     "minecraft:hide": {
                         "type": "object"
@@ -3323,7 +3509,15 @@
                         "type": "object"
                     },
                     "minecraft:knockback_resistance": {
-                        "type": "object"
+                        "type": "object",
+                        "properties": {
+                            "value": {
+                                "type": "number"
+                            },
+                            "max": {
+                                "type": "number"
+                            }
+                        }
                     },
                     "minecraft:lava_movement": {
                         "type": "object"
@@ -3461,7 +3655,18 @@
                         "type": "object"
                     },
                     "minecraft:pushable": {
-                        "type": "object"
+                        "type": "object",
+                        "description": "Defines what can push an entity between other entities and pistons.",
+                        "properties": {
+                            "is_pushable": {
+                                "type": "boolean",
+                                "description": "Whether the entity can be pushed by other entities."
+                            },
+                            "is_pushable_by_piston": {
+                                "type": "boolean",
+                                "description": "Whether the entity can be pushed by pistons safely."
+                            }
+                        }
                     },
                     "minecraft:push_through": {
                         "type": "object",
@@ -3548,7 +3753,51 @@
                         "type": "object"
                     },
                     "minecraft:timer": {
-                        "type": "object"
+                        "type": "object",
+                        "properties": {
+                            "looping": {
+                                "type": "boolean",
+                                "description": "If true, the timer will restart every time after it fires."
+                            },
+                            "time": {
+                                "type": "array",
+                                "description": "Amount of time in seconds for the timer. Can be specified as a number or a pair of numbers (min and max). Incompatible with random_time_choices.",
+                                "items": {
+                                    "type": "number"
+                                }
+                            },
+                            "randomInterval": {
+                                "type": "boolean",
+                                "description": "If true, the amount of time on the timer will be random between the min and max values specified in time."
+                            },
+                            "random_time_choices": {
+                                "type": "array",
+                                "description": "This is a list of objects, representing one value in seconds that can be picked before firing the event and an optional weight. Incompatible with time.",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "weight": {
+                                            "type": "number"
+                                        },
+                                        "value": {
+                                            "type": "number"
+                                        }
+                                    }
+                                }
+                            },
+                            "time_down_event": {
+                                "type": "object",
+                                "description": "Event to fire when the time on the timer runs out.",
+                                "properties": {
+                                    "event": {
+                                        "type": "string"
+                                    },
+                                    "target": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
                     },
                     "minecraft:trade_resupply": {
                         "type": "object"
@@ -3569,7 +3818,17 @@
                         "type": "object"
                     },
                     "minecraft:type_family": {
-                        "type": "object"
+                        "type": "object",
+                        "description": "Defines the families this entity belongs to.",
+                        "properties": {
+                            "family": {
+                                "type": "array",
+                                "description": "List of family names.",
+                                "items": {
+                                    "type": "string"
+                                }
+                            }
+                        }
                     },
                     "minecraft:underwater_movement": {
                         "type": "object"


### PR DESCRIPTION
I implemented some of the more frequently used components:

- attack
- boss
- collision_box
- despawn
- entity_sensor
- healable
- health
- knockback_resistance
- pushable
- timer
- type_family

Also I added enum for all potion effects and added another case to filters, so it can work with "has_damage" test.