### PR TITLE
Add missing components, fix misplaced brackets and minor improvements

### DIFF
--- a/index.json
+++ b/index.json
@@ -3673,6 +3673,7 @@
                         "description": "Sets the distance through which the entity can push through.",
                         "properties": {
                             "value": { "$ref": "#/definitions/library/components/values/value_decimal", "default": 0.002, "description": "The value of the entity's push-through, in blocks" }
+                         }
                     },
                     "minecraft:preferred_path": {
                         "type": "object"

--- a/index.json
+++ b/index.json
@@ -179,6 +179,10 @@
                     "then": { "properties": { "value": { "type": "string", "$ref": "#/definitions/library/filters/values/components" } } }
                 },
                 {
+                    "if": { "properties": { "test": { "anyOf": [ { "const": "is_difficulty" } ] } } },
+                    "then": { "properties": { "value": { "type": "string", "$ref": "#/definitions/library/difficulties" } } }
+                },
+                {
                     "if": { "properties": { "test": { "anyOf": [ { "const": "has_equipment" } ] } } },
                     "then": { "allOf": [
                         {"properties": { "domain": { "type": "string", "$ref": "#/definitions/library/filters/domains/has_equipment" } } },
@@ -349,6 +353,8 @@
                     },
                     "components": {
                         "enum": [
+                            "minecraft:annotation.break_door",
+                            "minecraft:annotation.open_door",
                             "minecraft:behavior.hide",
                             "minecraft:behavior.move_to_poi",
                             "minecraft:behavior.scared",
@@ -477,6 +483,7 @@
                             "minecraft:behavior.swim_with_entity",
                             "minecraft:behavior.swoop_attack",
                             "minecraft:behavior.take_flower",
+                            "minecraft:behavior.target_when_pushed",
                             "minecraft:behavior.tempt",
                             "minecraft:behavior.trade_interest",
                             "minecraft:behavior.trade_with_player",
@@ -2039,8 +2046,36 @@
                     "village_hero"
                 ]
             },
+            "difficulties": {
+                "enum": [
+                    "peaceful",
+                    "easy",
+                    "normal",
+                    "hard"
+                ]
+            },
             "components": {
                 "properties": {
+                    "minecraft:annotation.break_door": {
+                        "type": "object",
+                        "properties": {
+                            "break_time": {
+                                "type": "decimal",
+                                "default": 12.0,
+                                "description": "The time in seconds required to break through doors."
+                            },
+                            "min_difficulty": {
+                                "type": "string",
+                                "default": "hard",
+                                "$ref": "#/definitions/library/difficulties",
+                                "description": "The minimum difficulty that the world must be on for this entity to break doors."
+                            }
+                        },
+                        "description": "Allows the actor to break doors assuming that that flags set up for the component to use in navigation."
+                    },
+                    "minecraft:annotation.open_door": {
+                        "type": "object"
+                    },
                     "minecraft:behavior.hide": {
                         "type": "object",
                         "properties": {
@@ -2467,6 +2502,9 @@
                             "on_home": { "$ref": "#/definitions/library/components/values/trigger", "description": "Event to run when this mob gets home." },
                             "speed_multiplier": { "$ref": "#/definitions/library/components/values/speed_multiplier" }
                         }
+                    },
+                    "minecraft:behavior.guardian_attack": {
+                        "type": "object"
                     },
                     "minecraft:behavior.harvest_farm_block": {
                         "type": "object",
@@ -2987,6 +3025,9 @@
                         "type": "object"
                     },
                     "minecraft:behavior.swoop_attack": {
+                        "type": "object"
+                    },
+                    "minecraft:behavior.target_when_pushed": {
                         "type": "object"
                     },
                     "minecraft:behavior.take_flower": {
@@ -3607,6 +3648,9 @@
                         "type": "object"
                     },
                     "minecraft:navigation.walk": {
+                        "type": "object"
+                    },
+                    "minecraft:npc": {
                         "type": "object"
                     },
                     "minecraft:on_death": {

--- a/index.json
+++ b/index.json
@@ -3469,7 +3469,6 @@
                             },
                             {
                                 "properties": {
-                                    "type": "object",
                                     "interactions": {
                                         "type": "array",
                                         "items": [

--- a/index.json
+++ b/index.json
@@ -171,6 +171,10 @@
                     "then": { "properties": { "value": { "type": "boolean" } } }
                 },
                 {
+                    "if": { "properties": { "test": { "$ref": "#/definitions/library/filters/tests/string" } } },
+                    "then": { "properties": { "value": { "type": "string" } } }
+                },
+                {
                     "if": { "properties": { "test": { "anyOf": [ { "const": "has_component" } ] } } },
                     "then": { "properties": { "value": { "type": "string", "$ref": "#/definitions/library/filters/values/components" } } }
                 },
@@ -304,6 +308,11 @@
                             { "const": "is_skin_id" },
                             { "const": "is_altitude" },
                             { "const": "rider_count" }
+                        ]
+                    },
+                    "string": {
+                        "anyOf": [
+                            { "const": "is_family" }
                         ]
                     }
                 },
@@ -3671,6 +3680,7 @@
                         "type": "object",
                         "properties": {
                             "value": { "$ref": "#/definitions/library/components/values/value_decimal" }
+                        }
                     },
                     "minecraft:preferred_path": {
                         "type": "object"
@@ -3700,7 +3710,6 @@
                         "type": "object",
                         "properties": {
                             "value": { "$ref": "#/definitions/library/components/values/value_decimal" }
-                        }
                         }
                     },
                     "minecraft:scale_by_age": {

--- a/index.json
+++ b/index.json
@@ -3406,7 +3406,7 @@
                                     },
                                     "play_sounds": { "type": "string", "description": "List of sounds to play when the interaction occurs." },
                                     "spawn_entities": { "type": "string", "$ref": "#/definitions/library/entities", "description": "List of entities to spawn when the interaction occurs." },
-                                    "spawn_item": { "type": "object", "properties": { "table": { "$ref": "#/definitions/library/components/values/loot_table" } }, "description": "Loot table with items to drop on the ground upon successful interaction." },
+                                    "spawn_items": { "type": "object", "properties": { "table": { "$ref": "#/definitions/library/components/values/loot_table" } }, "description": "Loot table with items to drop on the ground upon successful interaction." },
                                     "swing": { "type": "boolean", "default": false, "description": "If true, the player will do the 'swing' animation when interacting with this entity." },
                                     "transform_to_item": {
                                         "type": "string",
@@ -3442,7 +3442,7 @@
                                                     },
                                                     "play_sounds": { "type": "string", "description": "List of sounds to play when the interaction occurs." },
                                                     "spawn_entities": { "type": "string", "$ref": "#/definitions/library/entities", "description": "List of entities to spawn when the interaction occurs." },
-                                                    "spawn_item": { "type": "object", "properties": { "table": { "$ref": "#/definitions/library/components/values/loot_table" } }, "description": "Loot table with items to drop on the ground upon successful interaction." },
+                                                    "spawn_items": { "type": "object", "properties": { "table": { "$ref": "#/definitions/library/components/values/loot_table" } }, "description": "Loot table with items to drop on the ground upon successful interaction." },
                                                     "swing": { "type": "boolean", "default": false, "description": "If true, the player will do the 'swing' animation when interacting with this entity." },
                                                     "transform_to_item": {
                                                         "type": "string",


### PR DESCRIPTION
Added missing components:
- minecraft:annotation.break_door
- minecraft:annotation.open_door
- minecraft:behavior.guardian_attack
- minecraft:behavior.target_when_pushed
- minecraft:npc

Added difficulty enum, added more cases for filters (is_difficulty, is_family), removed "type" from interact component properties and fixed typo spawn_item to spawn_items in interact component.

Also I fixed misplaced brackets. There was one bracket missing in push_through component and one extra bracket in scale component, which cause some components to be missing (since they were treated as fields in push_through component)